### PR TITLE
fix: use INPUT env instead of input.tag

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -35,7 +35,7 @@ runs:
       env:
         INPUT: ${{ inputs.tag }}
       run: |
-        if [ -n "${{ inputs.tag }}" ]; then
+        if [ -n "${INPUT}" ]; then
           echo "Using provided tag"
           echo "TAG=${INPUT}" >> "${GITHUB_ENV}"
           exit 0


### PR DESCRIPTION
To avoid command injection.

Signed-off-by: Hiroshi Muraoka <h.muraoka714@gmail.com>
