### PR TITLE
fix: overwrite tags by force push

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -72,5 +72,5 @@ runs:
       run: |
         git tag -f -a "${MAJOR_TAG}" -m "Release ${TAG}"
         git tag -f -a "${MINOR_TAG}" -m "Release ${TAG}"
-        git push origin "${MAJOR_TAG}" "${MINOR_TAG}"
+        git push -f origin "${MAJOR_TAG}" "${MINOR_TAG}"
 


### PR DESCRIPTION
Fix failing CI https://github.com/tapih/tag-semver-alias/actions/runs/8266772709/job/22615570712.

Signed-off-by: Hiroshi Muraoka <h.muraoka714@gmail.com>
